### PR TITLE
Nearest chargers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Create a .env file in then root and add the following
 
 ```
 PORT = 8080
-MONGODB_URI = mongodb://<<address>>:<<port>>
+MONGODB_URI = mongodb://<<address>>:<<port>>/EVAT
 JWT_SECRET = 'abc123'
 ```
 
@@ -41,7 +41,8 @@ https://www.mongodb.com/lp/cloud/atlas/try4-reg?utm_source=google&utm_campaign=s
 
 https://www.mongodb.com/resources/basics/databases/free 
 
-
+## Ensure MongoDB has the correct data and schema for chargers
+https://gist.github.com/EscWasTaken/3f08797d7470237ae3c2ed0dd149aace
 
 ## MongoDB Compass 
 A great tool for connecting, testing, editing, exporting and importing data into mongo databases.

--- a/server.ts
+++ b/server.ts
@@ -60,11 +60,15 @@ app.use(
   swaggerUi.setup(swaggerSpec, { explorer: true })
 );
 
+app.get("/api-docs/json", (req, res) => {
+  res.json(swaggerSpec);
+});
+
 // User Route
 app.use("/api/auth", UserRoutes);
 app.use("/api/profile", ProfileRoutes);
 app.use("/api/vehicle", VehicleRoutes);
-app.use("/api/station", StationRoutes);
+app.use("/api/chargers", StationRoutes); // As laid out in teams https://teams.microsoft.com/l/message/19:7206bda1ca594fa2a18709af5d9fb718@thread.v2/1743116771178?context=%7B%22contextType%22%3A%22chat%22%7D
 
 // Middleware
 app.use(notFound);

--- a/src/controllers/station-controller.ts
+++ b/src/controllers/station-controller.ts
@@ -27,7 +27,22 @@ export default class StationController {
 
             return res.status(200).json({
                 message: "success",
-                data: existingStation,
+                data: existingStation
+            });
+        } catch (error: any) {
+            return res.status(400).json({ message: error.message });
+        }
+    }
+
+    async getNearestStation(req: Request, res: Response): Promise<Response> {
+        const {lat, lon} = req.query;
+        try{
+            const nearestStation = await this.stationService.getNearestStation(
+                Number(lat), Number(lon) // Parameters are given as string but need to be numbers
+            )
+            return res.status(200).json({
+                message: "success",
+                data: nearestStation
             });
         } catch (error: any) {
             return res.status(400).json({ message: error.message });

--- a/src/models/station-model.ts
+++ b/src/models/station-model.ts
@@ -13,6 +13,10 @@ export interface IChargingStation extends Document {
   connection_type?: string;
   current_type?: string;
   charging_points_flag?: number;
+  location: {
+    type: string;
+    coordinates: [number, number]; // [latitude, longitude]
+  };
 }
 
 const ChargingStationSchema: Schema = new Schema<IChargingStation>(
@@ -29,12 +33,25 @@ const ChargingStationSchema: Schema = new Schema<IChargingStation>(
     connection_type: { type: String },
     current_type: { type: String },
     charging_points_flag: { type: Number },
+    location: {
+      type: {
+        type: String,
+        enum: ['Point'],
+        required: true,
+      },
+      coordinates: {
+        type: [Number], // [latitude, longitude]
+        required: true,
+      },
+    }
   },
   {
     timestamps: true, // Automatically add createdAt and updatedAt fields
     versionKey: false, // Disable the __v field
   }
 );
+
+ChargingStationSchema.index({ location: '2dsphere' });
 
 const ChargingStation = mongoose.model<IChargingStation>(
   "ChargingStation",

--- a/src/repositories/station-repository.ts
+++ b/src/repositories/station-repository.ts
@@ -15,6 +15,19 @@ class ChargingStationRepository {
       _id: { $in: stationIds },
     });
   }
+
+  async findNearest(lat: number, lon: number): Promise<IChargingStation | null> {
+    return await ChargingStation.findOne({
+      location: {
+        $nearSphere: {
+          $geometry: {
+            type: "Point",
+            coordinates: [lon, lat],
+          },
+        },
+      },
+    }).exec();
+  }
 }
 
 export default new ChargingStationRepository();

--- a/src/routes/profile-route.ts
+++ b/src/routes/profile-route.ts
@@ -18,8 +18,6 @@ const profileController = new ProfileController(
   stationService
 );
 
-//todo fix chargers schema
-
 /**
  * @swagger
  * components:
@@ -38,12 +36,43 @@ const profileController = new ProfileController(
  *     ChargingStation:
  *       type: object
  *       properties:
- *         id:
- *           type: string
- *         name:
+ *         _id:
  *           type: string
  *         location:
+ *           type: object
+ *           properties:
+ *             type:
+ *               type: string
+ *               example: "Point"
+ *             coordinates:
+ *               type: array
+ *               items:
+ *                 type: number
+ *               example: [145.1679215, -37.9420423]
+ *         cost:
  *           type: string
+ *         charging_points:
+ *           type: number
+ *         pay_at_location:
+ *           type: string
+ *         membership_required:
+ *           type: string
+ *         access_key_required:
+ *           type: string
+ *         is_operational:
+ *           type: string
+ *         latitude:
+ *           type: number
+ *         longitude:
+ *           type: number
+ *         operator:
+ *           type: string
+ *         connection_type:
+ *           type: string
+ *         current_type:
+ *           type: string
+ *         charging_points_flag:
+ *           type: number
  *     UserProfile:
  *       type: object
  *       properties:

--- a/src/routes/profile-route.ts
+++ b/src/routes/profile-route.ts
@@ -18,6 +18,8 @@ const profileController = new ProfileController(
   stationService
 );
 
+//todo fix chargers schema
+
 /**
  * @swagger
  * components:

--- a/src/routes/station-route.ts
+++ b/src/routes/station-route.ts
@@ -6,10 +6,10 @@ import StationController from "../controllers/station-controller";
 const router = Router();
 const stationService = new ChargingStationService();
 const stationController = new StationController(stationService);
-
+// Renamed station to chargers for api
 /**
  * @swagger
- * /api/station:
+ * /api/chargers:
  *   get:
  *     tags:
  *       - Chargers
@@ -41,6 +41,52 @@ router.get("/", authGuard(["user", "admin"]), (req, res) =>
     stationController.getAllStations(req, res)
 );
 
-//todo Implement other charger api calls (by id, by distance, and nearest)
+/**
+ * @swagger
+ * /api/chargers/nearest-charger:
+ *   get:
+ *     tags:
+ *       - Chargers
+ *     summary: Get nearest charger
+ *     description: Retrieves the nearest charger
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: lat
+ *         schema:
+ *           type: number
+ *         required: true
+ *         description: Latitude of the user's location.
+ *       - in: query
+ *         name: lon
+ *         schema:
+ *           type: number
+ *         required: true
+ *         description: Longitude of the user's location.
+ *     responses:
+ *       200:
+ *         description: Successfully retrieved chargers list
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "success"
+ *                 data:
+ *                   type: object
+ *                   $ref: '#/components/schemas/ChargingStation'
+ *       401:
+ *         description: Unauthorized
+ *       500:
+ *         description: Server error
+ */
+router.get("/nearest-charger", authGuard(['user', 'admin']), (req, res) =>
+    stationController.getNearestStation(req, res)
+);
+
+//todo Implement other charger api calls (by id, by distance, and nearest (✅))
 
 export default router;

--- a/src/services/station-service.ts
+++ b/src/services/station-service.ts
@@ -12,4 +12,8 @@ export default class ChargingStationService {
   async getStationsWithIdIn(stationIds: string[]) {
     return await ChargingStationRepository.findByIdIn(stationIds);
   }
+
+  async getNearestStation(lat: number, lon: number) {
+    return await ChargingStationRepository.findNearest(lat, lon)
+  }
 }


### PR DESCRIPTION
This push adds the nearest charger API call and back end code. As well as some other small changes.
Changes need to be made to the MongoDB charging_stations collection. These are documented [here](https://gist.github.com/EscWasTaken/3f08797d7470237ae3c2ed0dd149aace).
The README has been updated to add this link, and a change to the example connection string to ensure people use the correct "EVAT" Database otherwise the server just creates a blank "test" database.